### PR TITLE
Section 1.3 + 1.4

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -77,4 +77,21 @@ pub fn build(b: *std.Build) void {
 
     qemu_cmd.step.dependOn(iso_step);
     run_step.dependOn(&qemu_cmd.step);
+
+    const debug_step = b.step("debug", "Run kernel in QEMU with GDB server");
+
+    const qemu_debug = b.addSystemCommand(&.{
+        "qemu-system-x86_64",
+        "-cdrom",
+        "build/os.iso",
+        "-serial",
+        "stdio",
+        "-no-reboot",
+        "-no-shutdown",
+        "-s", // open gdbserver on port 1234
+        "-S", // pause CPU at startup, wait for GDB
+    });
+    qemu_debug.step.dependOn(iso_step);
+
+    debug_step.dependOn(&qemu_debug.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -50,4 +50,16 @@ pub fn build(b: *std.Build) void {
     // Bind the kernel artifact step to the default `zig build` command,
     // ensuring that our Kernel's build rules are executed by default.
     b.getInstallStep().dependOn(&kernel_artifact.step);
+
+    const iso_step = b.step("iso", "Build bootable ISO");
+
+    const iso_script = b.addSystemCommand(&.{
+        "bash",
+        "scripts/build-iso.sh",
+    });
+
+    iso_script.step.dependOn(&kernel_artifact.step);
+
+    iso_step.dependOn(&iso_script.step);
+    b.default_step.dependOn(iso_step);
 }

--- a/build.zig
+++ b/build.zig
@@ -62,4 +62,19 @@ pub fn build(b: *std.Build) void {
 
     iso_step.dependOn(&iso_script.step);
     b.default_step.dependOn(iso_step);
+
+    const run_step = b.step("run", "Run kernel in QEMU");
+
+    const qemu_cmd = b.addSystemCommand(&.{
+        "qemu-system-x86_64",
+        "-cdrom",
+        "build/os.iso",
+        "-serial",
+        "stdio",
+        "-no-reboot",
+        "-no-shutdown",
+    });
+
+    qemu_cmd.step.dependOn(iso_step);
+    run_step.dependOn(&qemu_cmd.step);
 }

--- a/docs/phase_01/NOTES.md
+++ b/docs/phase_01/NOTES.md
@@ -1,126 +1,332 @@
-# Phase 1 - Notes for `The Spark: Booting Into Your Kernel`
+# Phase 1 — The Spark: Booting Into Your Kernel
 
-## 1.1 Understand the boot chain
+---
+
+## 1.1 Understand the Boot Chain
 
 ### What I built
-Nothing
+Nothing — this was pure study.
 
 ### What I learned (concepts)
 
 #### Boot Sequence
-1. **Power On**: User presses power button
-2. **Firmware Execution**: CPU executes a hardcoded JUMP instruction to a predefined address in ROM where the firmware (**BIOS** or **UEFI**) is located
-3. **Hardware Init**: Firmware performs hardware test (**P**ower-**O**n **S**elf-**T**est , **POST**)
-    - If this fails, the booting halts
-4. **Bootloader Handoff**: The firmware loads partition table, looks for a bootable device and hands over to a bootloader (like Limine).
-    - **Legacy BIOS**: Reads the first 512 bytes of the disk (**M**aster **B**oot **R**ecord, **MBR**) to find the bootloader
-    - **UEFI**: Looks for a specific **FAT32** partition called the EFI System Partition (ESP) and runs a bootloader executable.
-5. **Kernel Execution**: The bootloader (Limine) prepares a standardized environment (memory maps, screen framebuffers), loads the OS kernel (e.g., `kernel.elf`) into RAM, and JUMPS to the kernel's entry point to hand over control.
+1. **Power On** — user presses power button.
+2. **Firmware Execution** — CPU executes a hardcoded JUMP to a fixed ROM address where the firmware (BIOS or UEFI) lives.
+3. **POST** — firmware performs Power-On Self-Test. Halts if hardware fails.
+4. **Bootloader Handoff** — firmware loads the partition table, finds a bootable device, and hands off to a bootloader:
+   - **Legacy BIOS**: reads the first 512 bytes of the disk (Master Boot Record, MBR).
+   - **UEFI**: finds a FAT32 EFI System Partition (ESP) and runs a bootloader executable.
+5. **Kernel Execution** — Limine prepares a standardized environment (memory maps, framebuffer), loads `kernel.elf` into RAM, and JUMPs to `_start`.
 
 #### BIOS vs UEFI
-**BIOS** (**B**asic **I**nput/**O**utput **S**ystem) is a firmware pre-installed on old motherboards that initializes hardware. It's constrained (e.g., 16-bit mode, limited space).
-
-**UEFI** (**U**nified **E**xtensible **F**irmware **I**nterface) is a modern replacement for legacy BIOS with more capabilities.
+- **BIOS** (Basic Input/Output System) — legacy firmware, 16-bit mode, limited space.
+- **UEFI** (Unified Extensible Firmware Interface) — modern replacement, richer capabilities.
 
 #### Limine
-Limine is an advanced, portable, multiprotocol bootloader that bridges the motherboard's firmware (BIOS/UEFI) and our custom OS kernel. It abstracts away the need to support both BIOS and UEFI directly.
+Limine bridges the motherboard firmware (BIOS/UEFI) and the kernel. It abstracts firmware differences, sets up 64-bit mode and paging, and gives the kernel a clean, standardized handoff.
 
 ### What surprised me
-
-- **Hardware bootstrapping is hardwired**: The CPU physically jumps to a fixed ROM address on power-up; this is not software-configurable. The bootstrap must be embedded in hardware itself.
-
-- **Historical constraints shape modern design**: The 512-byte MBR rule comes from ancient floppy disk sizes. Despite being obsolete, this constraint persists because firmware designers maintained backward compatibility.
-
-- **Abstraction through standardization**: Limine's value isn't doing magic—it's answering mundane questions (Where is RAM? What mode am I in? Where is the framebuffer?) so the kernel doesn't have to. This lets us focus on kernel logic, not firmware compatibility.
-
-- **Bootloader complexity justifies deferral**: Writing a bootloader requires 16-bit assembly, filesystem drivers, ELF parsing, and dual BIOS/UEFI support. It's a semester-long project on its own—better to use Limine and tackle it later if needed.
+- **Hardware bootstrapping is hardwired.** The CPU physically jumps to a fixed ROM address on power-up. Not software-configurable.
+- **Historical constraints shape modern design.** The 512-byte MBR rule comes from ancient floppy disk geometry and persists purely for backward compatibility.
+- **Bootloader complexity justifies deferral.** Writing a bootloader requires 16-bit assembly, filesystem drivers, ELF parsing, and dual BIOS/UEFI support — a project on its own.
 
 ### Open questions
-- How does Limine actually parse the ELF and know where to load sections?
-- What exactly is in the "standardized environment" Limine provides?
+- How does Limine actually parse the ELF and decide where to load each section?
+- What exactly is in the "standardized environment" Limine sets up before jumping to `_start`?
+
+---
 
 ## 1.2 The Linker Script
 
 ### What I built
-A working linker script (`kernel/linker.ld`) that places the kernel as a true higher-half kernel: virtual addresses start at `0xFFFFFFFF80100000`, mapped to physical address `0x100000` (1 MiB). The script uses `AT()` directives to define the virtual→physical split and a `/DISCARD/` rule to strip unused metadata sections. Alongside it, I configured `build.zig` to disable PIE and — critically — force the LLVM backend, which is what makes the linker script actually take effect.
+A working `kernel/linker.ld` that places the kernel as a true higher-half kernel: virtual addresses start at `0xFFFFFFFF80100000`, physical load address at `0x100000` (1 MiB). Uses `AT()` directives for the virtual/physical split and `/DISCARD/` to strip unused metadata. Alongside it, `build.zig` disables PIE and forces the LLVM backend.
 
 ### What I learned (concepts)
 
 #### Linker Script Purpose
-A linker script tells the linker how to organize compiled object files into the final executable and where each section lives in memory. For OS dev it's essential: the bootloader reads the ELF program headers to load each section to the right place.
+Tells the linker how to organize compiled object files into the final executable and where each section lives in memory. The bootloader reads ELF program headers to load each section to the correct address.
 
 #### Virtual vs Physical Addresses
-- **Virtual Address (VAddr):** where the CPU executes the code (what running code sees).
-- **Physical Address (PAddr):** where the bootloader places bytes in RAM.
-- Higher-half kernel: VAddr = `0xFFFFFFFF80100000+`, PAddr = `0x100000+`.
-- `AT(ADDR(.section) - KERNEL_VADDR_BASE)` computes the physical address by subtracting the high-half base from the virtual address.
+- **VAddr** — where the CPU executes code (what running code sees).
+- **PAddr** — where the bootloader places bytes in RAM.
+- `AT(ADDR(.section) - KERNEL_VADDR_BASE)` converts virtual to physical.
 
-#### Why higher-half / why 1 MiB physical
-- The kernel lives in the upper half so the lower half stays free for user space later.
-- `.text` is placed at base + 1 MiB so the physical load address is `0x100000`, avoiding the low-memory regions the firmware reserves.
+#### Why Higher-Half / Why 1 MiB Physical
+- Upper half reserved for the kernel; lower half stays free for future user space.
+- 1 MiB physical (`0x100000`) avoids low-memory regions reserved by firmware.
 
 #### GNU Linker Script Syntax
-- `ENTRY(symbol)` — sets the entry point (`_start`).
-- `SECTIONS { ... }` — maps input sections to output sections and addresses.
-- `.` — the location counter; the current virtual address. Assigning to it (`. = KERNEL_VADDR_TEXT;`) sets where the next section begins.
-- `ALIGN(4K)` — start the section on a 4 KiB page boundary (needed so each section can later get independent page permissions).
-- `AT(...)` — set the physical load address separately from the virtual address.
-- `*(.text)` — wildcard collecting all `.text` input sections from every object file.
-- `/DISCARD/ : { ... }` — drop matched sections from the output entirely.
+- `ENTRY(symbol)` — sets the entry point.
+- `SECTIONS { }` — maps input sections to output sections and addresses.
+- `.` — the location counter; tracks the current virtual address.
+- `ALIGN(4K)` — advance to the next 4 KiB boundary.
+- `AT(...)` — set physical load address separately from virtual address.
+- `*(.text)` — wildcard collecting all `.text` sections from all object files.
+- `/DISCARD/ { }` — drop matched sections from the output.
 
-#### Alignment to 4 KiB
-x86_64 manages memory in 4 KiB pages, and page permissions (R/W/X) are per-page. Aligning each section to a page boundary lets `.text` be executable, `.rodata` read-only, and `.data` read-write without any section's permissions bleeding into another.
+#### PIE
+- PIE on (default): linker emits relocatable code, ignores fixed addresses.
+- `exe.pie = false`: linker respects exact addresses. Required for a kernel.
 
-#### Position Independent Executable (PIE)
-- PIE on (default): linker emits relocatable code that can run at any address; it ignores fixed addresses.
-- `exe.pie = false`: linker respects the exact addresses. Required for a kernel — we *are* the OS, so there's no runtime relocator.
+#### Zig 0.16.0 Self-Hosted Backend Bug
+Zig 0.16.0 defaults to its own self-hosted x86_64 backend. That backend's ELF linker ignores the location counter (`. = ...;`) and silently substitutes `--image-base`. Nothing errors — the addresses are just wrong. Tracked in ziglang/zig#24717.
 
-#### The backend is what makes linker scripts work (the big one)
-- Recent Zig (including 0.16.0) **defaults to its own self-hosted x86_64 backend** instead of LLVM.
-- The self-hosted backend's ELF linker has **incomplete linker-script support**: it ignores the location counter (`. = ...;`) and substitutes `--image-base`, and it doesn't resolve linker-script-defined symbols (tracked in ziglang/zig#24717).
-- `exe.use_llvm = true` switches codegen to the **LLVM backend**, whose linker (LLD) honors the script properly. This is the fix.
+Fix: `exe.use_llvm = true` switches to the LLVM backend, whose linker (LLD) honors the script correctly.
 
-#### compiler_rt
-With the LLVM backend, `readelf` shows hundreds of `.text.compiler_rt.*` sections. These are compiler support routines (memcpy, memset, 128-bit division, software float math, oversized atomics) — primitives the CPU lacks single instructions for. They are *not* OS functionality and using them is not in tension with "from scratch" (even Linux/libgcc do this). They collapse into one clean `.text` LOAD segment; the long list is just `readelf` verbosity.
+Note: `use_lld = true` (linker only) and `use_llvm = true` (full backend) are different. Feeding self-hosted output to LLD directly caused a SEGFAULT.
 
-### Working configuration
-
-`build.zig`:
+### Working `build.zig` configuration
 ```zig
-exe.pie = false;       // kernel must not be PIE
-exe.use_llvm = true;   // LLVM backend → linker script is honored
+exe.pie = false;
+exe.use_llvm = true;
 exe.setLinkerScript(b.path("kernel/linker.ld"));
-// no image_base, no use_lld
 ```
 
 ### What surprised me
+- The self-hosted backend silently ignored the linker script. No error — just wrong addresses.
+- `use_lld` vs `use_llvm` are completely different. The fix was the codegen backend, not the linker.
+- A reference project (Ymir hypervisor) confirmed the script was correct and the backend was the variable.
 
-- **The default backend silently broke the linker script.** For hours the script was parsed and passed to the linker, yet its addresses were ignored — because the self-hosted backend's linker uses `--image-base` instead of the location counter. Nothing errored; the addresses were just wrong.
-- **`use_lld` vs `use_llvm` are different things.** `use_lld` swaps only the linker; feeding self-hosted-backend output to LLD segfaulted. `use_llvm` swaps the codegen backend (and brings LLD along correctly). The fix was the backend, not the linker.
-- **`image_base = 0xFFFFFFFF80000000` overflowed** the self-hosted linker — another symptom of the same incomplete support.
-- **A proven reference settled it:** the Ymir hypervisor produces a perfect high-half ELF with essentially this exact linker script, because it uses the LLVM backend. That confirmed the script was fine and the backend was the variable.
+### Verification evidence
+```
+Entry point 0xffffffff801171b0
+
+LOAD  0xffffffff80100000  0x0000000000100000  R E   (.text)
+LOAD  0xffffffff80140310  0x0000000000140310  RW    (.data)
+LOAD  0xffffffff80141000  0x0000000000141000  RW    (.bss)
+```
+
+### Open questions
+- Deferred: `exe.link_gc_sections = true` to strip unused compiler_rt functions (Phase 14 polish).
+
+---
+
+## 1.3 Limine Boot Setup
+
+### What I built
+Three Limine protocol request structs (`HHDMRequest`, `FrameBufferRequest`, `MemMapRequest`) in `kernel/limine.zig`, exported from `kernel/main.zig`. A bootable ISO built by `scripts/build-iso.sh`, wired into `build.zig` as `zig build iso` and `zig build run`. A working `kernel/limine.conf`. The kernel boots in QEMU: Limine loads `kernel.elf`, jumps to `_start`, and the CPU halts cleanly. GDB confirms the entry point.
+
+### What I learned (concepts)
+
+#### The Limine Protocol: Request/Response Model
+Before jumping to `_start`, Limine scans the loaded kernel image for request structs (identified by magic numbers). For each recognized request, it fills in the `response` pointer with data the kernel can read after boot.
+
+Three essential requests:
+- **HHDM** — gives the virtual offset mapping all physical memory into the upper half. Without it, physical addresses cannot be dereferenced from kernel code.
+- **Framebuffer** — gives a pointer to the screen's pixel buffer (already virtually mapped).
+- **Memory Map** — lists every RAM region (usable, reserved, ACPI, firmware, etc.).
+
+The fundamental relationship: `Virtual Address = Physical Address + HHDM Offset`
+
+#### Base Revisions
+Limine protocol versions are called base revisions. Revisions 0–5 are deprecated. Base Revision 6 is current. For x86-64, revisions 5 and 6 are identical; revision 6 only adds constraints for other architectures. Always target the latest.
+
+The base revision tag is a 3-element `u64` array: two magic values followed by the revision number. It must be present in the binary alongside the requests.
+
+#### Zig Struct Layouts for C Interop
+Three struct types exist in Zig with different memory guarantees:
+- `struct` — automatic layout; compiler may reorder fields. Cannot be `export`ed (no guaranteed in-memory representation).
+- `packed struct` — bit-level packing. Cannot contain arrays (`[4]u64` has no bit-packed representation).
+- `extern struct` — C-compatible layout; fields in order, natural alignment. Required for anything crossing an ABI boundary.
+
+#### Placing Variables in Linker Sections (Zig)
+The correct Zig idiom to place a variable in a specific linker section:
+```zig
+export var hhdm_request: limine.HHDMRequest linksection(".requests") = .{ ... };
+```
+This is the direct equivalent of GCC's `__attribute__((section("...")))`. Not `@export`, not `comptime` tricks — just `linksection`.
+
+#### `const` vs `var` for Limine Requests
+`export const` places data in `.rodata` (read-only memory). Limine writes the response pointer into the struct at load time. Writing to read-only memory faults. Always use `export var` so the struct lands in `.data` (writable).
+
+#### Duplicate Magic Symbols (LLVM Footgun)
+Named intermediate constants in Zig (e.g. `const hhdm_common_magic = [4]u64{...}`) cause LLVM to emit the array as a separate `.rodata` symbol. When used as a struct field default, the bytes appear twice in the binary. Limine's scanner found two HHDM request patterns and panicked with a duplicate request error.
+
+Fix: inline magic values directly into struct field defaults. No named intermediate constants.
+
+#### ISO 9660 Filename Truncation
+ISO 9660 Level 1 (the default) enforces 8.3 filenames. `limine.conf` (11 characters) is silently truncated to `limine.con`. Limine looks for `limine.conf` and finds nothing.
+
+Attempted fixes that did NOT work with macOS xorriso 1.5.8 `-as mkisofs`:
+- `-r`, `-J` (short forms)
+- `-rockridge`, `-joliet` (long forms — unrecognized)
+
+Fix that worked: **`-iso-level 4`** (ISO 9660:1999, supports names up to 207 characters). Found in the xorriso man page.
+
+#### Limine Config File Syntax (v11.x)
+Wrong (old-style):
+```
+:Zig OS
+PROTOCOL=limine
+KERNEL_PATH=boot:///kernel.elf
+```
+
+Correct:
+```
+timeout: 5
+
+/ Zig OS
+    protocol: limine
+    kernel_path: boot():/boot/limine/kernel.elf
+```
+
+Key differences:
+- Entry names start with `/`, not `:`
+- Options use `key: value`, not `KEY=VALUE`
+- Path syntax is `resource(argument):/path`; `boot()` means "partition containing the config file"
+
+#### Limine Config File Search Order (BIOS)
+Limine scans the boot drive's partitions in order and looks for the config at:
+1. `/boot/limine/limine.conf`
+2. `/boot/limine.conf`
+3. `/limine/limine.conf`
+4. `/limine.conf`
+
+ISO staging structure that works:
+```
+iso_root/
+├── boot/limine/
+│   ├── kernel.elf
+│   ├── limine.conf
+│   ├── limine-bios.sys        (used by bios-install)
+│   ├── limine-bios-cd.bin     (the El Torito boot image)
+│   └── limine-uefi-cd.bin
+└── EFI/BOOT/
+    └── BOOTX64.EFI
+```
+
+#### ELF Segment Alignment (Limine Requirement)
+Limine enforces that no two LOAD segments with different permissions share the same 4K memory page. If `.text` (R E) and `.data` (RW) touch the same page, Limine panics:
+```
+PANIC: elf: Attempted to load ELF file with PHDRs with different permissions
+sharing the same memory page.
+```
+
+Fix: place `. = ALIGN(4K);` between sections in the linker script, outside the section braces.
+
+- Inside braces: creates extra output sections (wrong).
+- In the section header as `ALIGN(4K)` alone: insufficient with LLD.
+- Between sections as `. = ALIGN(4K);`: correct.
+
+Working linker script pattern:
+```ld
+.text ALIGN(4K) : AT(ADDR(.text) - KERNEL_VADDR_BASE)
+{
+  *(.text)
+  *(.rodata*)
+}
+
+. = ALIGN(4K);
+.data : AT(ADDR(.data) - KERNEL_VADDR_BASE)
+{
+  *(.data)
+}
+
+. = ALIGN(4K);
+.bss : AT(ADDR(.bss) - KERNEL_VADDR_BASE)
+{
+  *(COMMON)
+  *(.bss)
+}
+
+. = ALIGN(4K);
+.requests : AT(ADDR(.requests) - KERNEL_VADDR_BASE)
+{
+  *(.requests)
+}
+```
+
+---
+
+### Walls hit and how they were resolved
+
+**Wall 1: `packed struct` rejects `[4]u64`**
+Zig's `packed struct` requires all fields to have a bit-packed representation. Arrays don't qualify.
+Fix: use `extern struct`.
+
+**Wall 2: `struct` cannot be `export`ed**
+Regular Zig structs have automatic layout with no in-memory guarantee. The compiler refuses to export them.
+Fix: use `extern struct` (C-compatible layout, exportable).
+
+**Wall 3: `export const` prevents Limine from writing the response pointer**
+Limine writes the response pointer into the struct at load time. `const` → `.rodata` → read-only → fault.
+Fix: use `export var`.
+
+**Wall 4: Duplicate magic constants caused Limine to find two HHDM requests**
+Named intermediate constants caused LLVM to emit the magic bytes twice. Limine panicked on duplicate requests.
+Fix: inline magic values directly into struct field defaults.
+
+**Wall 5: `linksection` was not being used**
+Without `linksection(".requests")`, the request structs were placed in `.data` by default. Limine couldn't locate them through its section scanner.
+Fix: add `linksection(".requests")` to every request variable declaration.
+
+**Wall 6: `limine.conf` truncated to `limine.con` in the ISO**
+ISO 9660 Level 1 enforces 8.3 filenames. Flags `-r`, `-J`, `-rockridge`, `-joliet` all failed on macOS xorriso.
+Fix: `-iso-level 4` found in the xorriso man page.
+
+**Wall 7: Boot menu shows `[config file not found]` despite correct filenames**
+The config was at `/boot/limine.conf` instead of `/boot/limine/limine.conf`. Limine searches specific paths in a specific order.
+Fix: restructure the staging directory to `/boot/limine/limine.conf`.
+
+**Wall 8: Boot menu shows `[config file contains no valid entries]`**
+The config used old syntax (`:EntryName`, `KEY=VALUE`, `boot:///path`). Limine v11.x uses different syntax.
+Fix: rewrite config to `/ EntryName`, `key: value`, `boot():/path`.
+
+**Wall 9: Limine panics on ELF segment alignment**
+`.data` was at `0xffffffff80140430` (not 4K aligned), sharing a page with `.text`.
+Fix: `. = ALIGN(4K);` between sections in the linker script.
+
+**Wall 10: Limine v7.x was 3 years old**
+Initially cloned `v7.x-binary`. Upgraded to `v11.x-binary`. Newer Limine has stricter validation that caught real bugs in the kernel binary.
+
+---
+
+### What surprised me
+- `linksection` is the Zig idiom for section placement. One attribute, straightforward.
+- `const` vs `var` has security-relevant consequences when the bootloader writes into your struct.
+- Duplicate symbol emission from named constants is a real footgun. A magic-number constant triggering a bootloader panic is not obvious.
+- Old Limine (v7.x) silently accepted broken binaries that new Limine (v11.x) correctly rejects. Always use a recent bootloader.
+- The xorriso man page had the fix (`-iso-level 4`) that none of the common flags provided.
+- **A blank screen is success.** No output code exists yet. The kernel is halted in `cli; hlt`. Exactly correct.
+
+---
 
 ### What I'd do differently
+- Start with `extern struct` for anything crossing an ABI boundary.
+- Use `linksection` from the first draft of any protocol struct.
+- Check `readelf -S` for section names before debugging bootloader behavior.
+- Use the latest Limine binary from day one. Old versions hide bugs.
+- Read `CONFIG.md` before writing `limine.conf`. Don't guess syntax.
+- Check the man page before trying multiple flags that all fail.
 
-- When a linker script is parsed but ignored, suspect the **backend/linker**, not the script syntax. Check `use_llvm` early on Zig ≥ 0.14.
-- Find a known-good reference project (Ymir, limine-zig) early and diff its `build.zig` against mine before deep debugging.
-- Verify with `readelf -l` (program headers) from the start — it shows the real VAddr/PAddr split, which is the actual success metric.
+---
 
 ### Verification evidence
 
-`readelf -l build/kernel.elf` after the fix and `/DISCARD/`:
+`.requests` section in the binary:
 ```
-Entry point 0xffffffff801171b0
-Type   VirtAddr             PhysAddr             Flags
-LOAD   0xffffffff80100000   0x0000000000100000   R E    (.text)
-LOAD   0xffffffff80140310   0x0000000000140310   RW     (.data)
-LOAD   0xffffffff80141000   0x0000000000141000   RW     (.bss)
+[449] .requests   PROGBITS   ffffffff80141000   00042000
 ```
 
-Three clean LOAD segments; virtual addresses in the higher half, physical at 1 MiB; entry point inside `.text`. Exactly the intended layout.
+GDB session confirming `_start` is reached:
+```
+(gdb) target remote :1234
+(gdb) break _start
+Breakpoint 1 at 0xffffffff801171b0: file main.zig, line 31.
+(gdb) continue
+Breakpoint 1, main._start () at main.zig:31
+31    asm volatile ("cli");
+(gdb) next
+33        asm volatile ("hlt");
+(gdb) info registers rip rsp eflags
+rip    0xffffffff801171b2
+rsp    0xffff800007f98ff8
+```
 
-### Open questions (resolved + deferred)
+---
 
-- **RESOLVED — higher-half mapping on Zig 0.16.0/macOS:** earlier I believed this was impossible and had to be deferred to Phase 6. That was wrong. The cause was the default self-hosted backend (ziglang/zig#24717); `exe.use_llvm = true` fixes it. The kernel is now correctly higher-half from the start.
-- **Possible bug to report:** `exe.use_lld = true` (with the self-hosted backend) produced a hard SEGV rather than a clean error. A crash is arguably a real bug worth filing on Codeberg, separate from the known #24717.
-- **Deferred (Phase 14 polish):** the bundled `compiler_rt` includes many functions the kernel never calls. Link-time section GC (~`exe.link_gc_sections = true`, verify the exact field) could strip the unused ones. Purely a size concern; not needed now.
+### Open questions
+- How does Limine parse the ELF? It reads program headers, checks permissions, and validates alignment before mapping — the alignment panic proves it validates before loading.
+- What is the full machine state at `_start`? The Limine spec lists it (GDT, IDT, paging, stack) but we haven't inspected it yet. Phase 3 work.
+- Where does `rsp = 0xffff800007f98ff8` come from? This is Limine's provided stack. We replace it with our own in Phase 3.
+- What does the HHDM offset actually resolve to at runtime? We declared the request but haven't read the response yet. Phase 2 work.

--- a/docs/phase_01/README.md
+++ b/docs/phase_01/README.md
@@ -54,7 +54,7 @@
   - **Verify:** The file syntax matches the Limine docs.
   - **Notes:**
 
-- [ ] **Update `_start` to halt cleanly**
+- [x] **Update `_start` to halt cleanly**
   - **Why:** "Looping forever" with `while(true)` wastes CPU and is harder to spot in QEMU. `cli; hlt` is the canonical "kernel is alive and waiting" pose.
   - **Study:** What `cli` and `hlt` do at the CPU level. Why interrupts must be disabled before halt.
   - **What:** Replace your infinite loop with inline assembly: `cli`, then a loop of `hlt`.
@@ -63,20 +63,20 @@
 
 ## 1.4 Build the bootable ISO
 
-- [ ] **Add ISO build steps to `build.zig`**
+- [x] **Add ISO build steps to `build.zig`**
   - **Why:** Automating this means you can iterate fast. Manual steps will exhaust you.
   - **Study:** Limine's "How to install" instructions. The role of `limine-bios.sys`, `limine-uefi-cd.bin`, and `limine bios-install`.
   - **What:** Add a `zig build iso` step that: copies the kernel + Limine binaries + config into a staging folder, runs `xorriso` to make the ISO, runs `limine bios-install` to make it bootable.
   - **Verify:** `zig build iso` produces `os.iso` in `zig-out/`.
   - **Notes:**
 
-- [ ] **Add a `zig build run` step**
+- [x] **Add a `zig build run` step**
   - **Why:** One command to build and boot. Critical for fast iteration.
   - **What:** Add a step that runs `qemu-system-x86_64 -cdrom zig-out/os.iso -serial stdio -no-reboot -no-shutdown`.
   - **Verify:** `zig build run` launches QEMU.
   - **Notes:**
 
-- [ ] **Boot your kernel for the first time**
+- [x] **Boot your kernel for the first time**
   - **Why:** This is the milestone moment.
   - **What:** Run `zig build run`.
   - **Verify:** QEMU shows a black screen (or the Limine logo briefly) and stays running. No reboots. No "no bootable device" errors.

--- a/docs/phase_01/README.md
+++ b/docs/phase_01/README.md
@@ -33,7 +33,7 @@
   - **Verify:** `readelf -l zig-out/bin/kernel.elf` shows program headers at the addresses you specified.
   - **Notes:**
 
-- [ ] **Wire the linker script into `build.zig`**
+- [x] **Wire the linker script into `build.zig`**
   - **Why:** Zig needs to know to use your custom script.
   - **What:** Pass `-T linker.ld` (or the Zig equivalent: `setLinkerScript`).
   - **Verify:** Rebuild — addresses in `readelf` now match your script.

--- a/docs/phase_01/README.md
+++ b/docs/phase_01/README.md
@@ -41,14 +41,14 @@
 
 ## 1.3 Limine boot setup
 
-- [ ] **Add Limine requests to your kernel**
+- [x] **Add Limine requests to your kernel**
   - **Why:** Limine only gives you the information you ask for. You request features via specially-marked structs in your binary.
   - **Study:** Limine "requests" — how they work, why they're put in a dedicated `.requests` section.
   - **What:** Add a base revision marker and a framebuffer request to your kernel. Put them in a `.requests` section in the linker script.
   - **Verify:** `readelf -S` shows the `.requests` section in your ELF.
   - **Notes:**
 
-- [ ] **Write `limine.conf`**
+- [x] **Write `limine.conf`**
   - **Why:** Limine reads this to know which kernel to load.
   - **What:** Create a boot entry pointing to `boot:///kernel.elf` with protocol `limine`.
   - **Verify:** The file syntax matches the Limine docs.

--- a/kernel/limine.conf
+++ b/kernel/limine.conf
@@ -1,0 +1,10 @@
+# Timeout in seconds
+# Wait 5 seconds on the menu before auto-selecting the first entry
+TIMEOUT=5
+
+# Boot entry label
+:Zig OS
+# Use limine protocol
+PROTOCOL=limine
+KERNEL_PATH=boot:///kernel.elf
+KERNEL_CMDLINE=root=/dev/null

--- a/kernel/limine.conf
+++ b/kernel/limine.conf
@@ -1,10 +1,5 @@
-# Timeout in seconds
-# Wait 5 seconds on the menu before auto-selecting the first entry
-TIMEOUT=5
+timeout: 5
 
-# Boot entry label
-:Zig OS
-# Use limine protocol
-PROTOCOL=limine
-KERNEL_PATH=boot:///kernel.elf
-KERNEL_CMDLINE=root=/dev/null
+/ Zig OS
+    protocol: limine
+    kernel_path: boot():/boot/limine/kernel.elf

--- a/kernel/limine.zig
+++ b/kernel/limine.zig
@@ -1,15 +1,15 @@
 // ----------------------------------------------------
 // Limine Common Magic
 // ----------------------------------------------------
+
 const limine_common_magic = [2]u64{ 0xc7b1dd30df4c8b88, 0x0a82e883a194f07b };
 
 // ----------------------------------------------------
 // HHDM (Higher Half Direct Map) Feature
 // ----------------------------------------------------
-const hhdm_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x48dcf1cb8ad2b852, 0x63984e959a98244b };
 
 pub const HHDMRequest = extern struct {
-    id: [4]u64 = hhdm_common_magic,
+    id: [4]u64 = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x48dcf1cb8ad2b852, 0x63984e959a98244b },
     revision: u64,
     response: ?*HHDMResponse,
 };
@@ -22,10 +22,9 @@ pub const HHDMResponse = extern struct {
 // ----------------------------------------------------
 // FrameBuffer Feature
 // ----------------------------------------------------
-const framebuffer_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x9d5827dcd881dd75, 0xa3148604f6fab11b };
 
 pub const FrameBufferRequest = extern struct {
-    id: [4]u64 = framebuffer_common_magic,
+    id: [4]u64 = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x9d5827dcd881dd75, 0xa3148604f6fab11b },
     revision: u64,
     response: ?*FrameBufferResponse,
 };
@@ -75,7 +74,6 @@ pub const VideoMode = extern struct {
 // ----------------------------------------------------
 // Memory Map Feature
 // ----------------------------------------------------
-const memmap_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x67cf3d9d378a806f, 0xe304acdfc50c3c62 };
 
 pub const MemmapEntryType = enum(u64) {
     usable = 0,
@@ -97,7 +95,7 @@ pub const MemmapEntry = extern struct {
 };
 
 pub const MemMapRequest = extern struct {
-    id: [4]u64 = memmap_common_magic,
+    id: [4]u64 = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x67cf3d9d378a806f, 0xe304acdfc50c3c62 },
     revision: u64,
     response: ?*MemMapResponse,
 };

--- a/kernel/limine.zig
+++ b/kernel/limine.zig
@@ -1,0 +1,109 @@
+// ----------------------------------------------------
+// Limine Common Magic
+// ----------------------------------------------------
+const limine_common_magic = [2]u64{ 0xc7b1dd30df4c8b88, 0x0a82e883a194f07b };
+
+// ----------------------------------------------------
+// HHDM (Higher Half Direct Map) Feature
+// ----------------------------------------------------
+const hhdm_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x48dcf1cb8ad2b852, 0x63984e959a98244b };
+
+pub const HHDMRequest = extern struct {
+    id: [4]u64 = hhdm_common_magic,
+    revision: u64,
+    response: ?*HHDMResponse,
+};
+
+pub const HHDMResponse = extern struct {
+    revision: u64,
+    offset: u64,
+};
+
+// ----------------------------------------------------
+// FrameBuffer Feature
+// ----------------------------------------------------
+const framebuffer_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x9d5827dcd881dd75, 0xa3148604f6fab11b };
+
+pub const FrameBufferRequest = extern struct {
+    id: [4]u64 = framebuffer_common_magic,
+    revision: u64,
+    response: ?*FrameBufferResponse,
+};
+
+pub const FrameBufferResponse = extern struct {
+    revision: u64,
+    framebuffer_count: u64,
+    framebuffers: ?[*]*FrameBuffer,
+};
+
+pub const FrameBuffer = extern struct {
+    address: *void,
+    width: u64,
+    height: u64,
+    pitch: u64,
+    bpp: u16, // bits per pixel
+    memory_model: u8,
+    red_mask_size: u8,
+    red_mask_shift: u8,
+    green_mask_size: u8,
+    green_mask_shift: u8,
+    blue_mask_size: u8,
+    blue_mask_shift: u8,
+    unused: [7]u8,
+    edid_size: u64,
+    edid: *void,
+
+    // Response Revision
+    mode_count: u64,
+    video_mode: ?[*]*VideoMode,
+};
+
+pub const VideoMode = extern struct {
+    pitch: u64,
+    width: u64,
+    height: u64,
+    bpp: u16, // bits per pixel
+    memory_model: u8,
+    red_mask_size: u8,
+    red_mask_shift: u8,
+    green_mask_size: u8,
+    green_mask_shift: u8,
+    blue_mask_size: u8,
+    blue_mask_shift: u8,
+};
+
+// ----------------------------------------------------
+// Memory Map Feature
+// ----------------------------------------------------
+const memmap_common_magic = [4]u64{ limine_common_magic[0], limine_common_magic[1], 0x67cf3d9d378a806f, 0xe304acdfc50c3c62 };
+
+pub const MemmapEntryType = enum(u64) {
+    usable = 0,
+    reserved = 1,
+    acpi_reclaimable = 2,
+    acpi_nvs = 3,
+    bad_memory = 4,
+    bootloader_reclaimable = 5,
+    executable_and_modules = 6,
+    framebuffer = 7,
+    reserved_mapped = 8,
+    _,
+};
+
+pub const MemmapEntry = extern struct {
+    base: u64,
+    length: u64,
+    type: MemmapEntryType,
+};
+
+pub const MemMapRequest = extern struct {
+    id: [4]u64 = memmap_common_magic,
+    revision: u64,
+    response: ?*MemMapResponse,
+};
+
+pub const MemMapResponse = extern struct {
+    revision: u64,
+    entry_count: u64,
+    entries: ?[*]*MemmapEntry,
+};

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -72,6 +72,11 @@ SECTIONS
     *(.bss)
   }
 
+  .requests ALIGN(8) : AT(ADDR(.requests) - KERNEL_VADDR_BASE)
+  {
+    *(.requests)
+  }
+
   /*
    * /DISCARD/ throws away sections we don't want in the final image.
    * .eh_frame / .eh_frame_hdr are exception-unwind tables we don't use,

--- a/kernel/main.zig
+++ b/kernel/main.zig
@@ -1,3 +1,27 @@
+const limine = @import("limine.zig");
+
+export const base_revision: [3]u64 align(8) = .{
+    0xf9562b2d5c95a6c8,
+    0x6a7b384944536bdc,
+    6, // Base Revision 6
+};
+
+// Requests
+export const hhdm_request: limine.HHDMRequest align(8) = .{
+    .revision = 0,
+    .response = null,
+};
+
+export const framebuffer_request: limine.FrameBufferRequest align(8) = .{
+    .revision = 0,
+    .response = null,
+};
+
+export const memmap_request: limine.MemMapRequest align(8) = .{
+    .revision = 0,
+    .response = null,
+};
+
 // _start is the entry point of the OS
 // `noreturn` is used because a infinite loop doesn't return anything.
 // callconv(.naked)

--- a/kernel/main.zig
+++ b/kernel/main.zig
@@ -1,23 +1,23 @@
 const limine = @import("limine.zig");
 
-export const base_revision: [3]u64 align(8) = .{
+export var base_revision: [3]u64 align(8) = .{
     0xf9562b2d5c95a6c8,
     0x6a7b384944536bdc,
     6, // Base Revision 6
 };
 
 // Requests
-export const hhdm_request: limine.HHDMRequest align(8) = .{
+export var hhdm_request: limine.HHDMRequest align(8) linksection(".requests") = .{
     .revision = 0,
     .response = null,
 };
 
-export const framebuffer_request: limine.FrameBufferRequest align(8) = .{
+export var framebuffer_request: limine.FrameBufferRequest align(8) linksection(".requests") = .{
     .revision = 0,
     .response = null,
 };
 
-export const memmap_request: limine.MemMapRequest align(8) = .{
+export var memmap_request: limine.MemMapRequest align(8) linksection(".requests") = .{
     .revision = 0,
     .response = null,
 };

--- a/kernel/main.zig
+++ b/kernel/main.zig
@@ -28,5 +28,8 @@ export const memmap_request: limine.MemMapRequest align(8) = .{
 //  The callconv specifier changes the calling convention of the function.
 //  .naked makes it no have a prologue/epilogue
 export fn _start() callconv(.naked) noreturn {
-    while (true) {}
+    asm volatile ("cli");
+    while (true) {
+        asm volatile ("hlt");
+    }
 }

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+LIMINE_DIR="$PROJECT_ROOT/../../limine-bootloader/limine"
+KERNEL_ELF="$PROJECT_ROOT/build/kernel.elf"
+LIMINE_CONF="$PROJECT_ROOT/kernel/limine.conf"
+STAGING_DIR="$PROJECT_ROOT/build/iso_root"
+ISO_OUTPUT="$PROJECT_ROOT/build/os.iso"
+
+# Clean and create staging directory
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR/boot/EFI/BOOT"
+
+# Copy kernel
+cp "$KERNEL_ELF" "$STAGING_DIR/boot/"
+
+# Copy Limine config
+cp "$LIMINE_CONF" "$STAGING_DIR/boot/"
+
+# Copy Limine bootloader files
+cp "$LIMINE_DIR/limine-bios.sys" "$STAGING_DIR/boot/"
+cp "$LIMINE_DIR/limine-uefi-cd.bin" "$STAGING_DIR/boot/EFI/BOOT/BOOTX64.EFI"
+
+# Create ISO with xorriso
+xorriso -as mkisofs -b boot/limine-bios.sys \
+  -no-emul-boot -boot-load-size 4 -boot-info-table \
+  --efi-boot boot/EFI/BOOT/BOOTX64.EFI \
+  -efi-boot-part --efi-boot-image --protective-msdos-label \
+  -o "$ISO_OUTPUT" "$STAGING_DIR"
+
+# Make it BIOS bootable
+"$LIMINE_DIR/limine" bios-install "$ISO_OUTPUT"
+
+echo "✓ ISO created: $ISO_OUTPUT"

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -9,24 +9,32 @@ LIMINE_CONF="$PROJECT_ROOT/kernel/limine.conf"
 STAGING_DIR="$PROJECT_ROOT/build/iso_root"
 ISO_OUTPUT="$PROJECT_ROOT/build/os.iso"
 
-# Clean and create staging directory
+# Clean and create staging directories
 rm -rf "$STAGING_DIR"
-mkdir -p "$STAGING_DIR/boot/EFI/BOOT"
+mkdir -p "$STAGING_DIR/boot/limine"
+mkdir -p "$STAGING_DIR/EFI/BOOT"
 
 # Copy kernel
-cp "$KERNEL_ELF" "$STAGING_DIR/boot/"
+cp "$KERNEL_ELF" "$STAGING_DIR/boot/limine/"
 
-# Copy Limine config
-cp "$LIMINE_CONF" "$STAGING_DIR/boot/"
+# Copy Limine config to all search locations
+cp "$LIMINE_CONF" "$STAGING_DIR/boot/limine/"
+cp "$LIMINE_CONF" "$STAGING_DIR/boot/limine.conf"
+mkdir -p "$STAGING_DIR/limine"
+cp "$LIMINE_CONF" "$STAGING_DIR/limine/limine.conf"
+cp "$LIMINE_CONF" "$STAGING_DIR/limine.conf"
 
 # Copy Limine bootloader files
-cp "$LIMINE_DIR/limine-bios.sys" "$STAGING_DIR/boot/"
-cp "$LIMINE_DIR/limine-uefi-cd.bin" "$STAGING_DIR/boot/EFI/BOOT/BOOTX64.EFI"
+cp "$LIMINE_DIR/limine-bios.sys" "$STAGING_DIR/boot/limine/"
+cp "$LIMINE_DIR/limine-bios-cd.bin" "$STAGING_DIR/boot/limine/"
+cp "$LIMINE_DIR/limine-uefi-cd.bin" "$STAGING_DIR/boot/limine/"
+cp "$LIMINE_DIR/BOOTX64.EFI" "$STAGING_DIR/EFI/BOOT/"
 
 # Create ISO with xorriso
-xorriso -as mkisofs -b boot/limine-bios.sys \
+xorriso -as mkisofs -iso-level 4 \
+  -b boot/limine/limine-bios-cd.bin \
   -no-emul-boot -boot-load-size 4 -boot-info-table \
-  --efi-boot boot/EFI/BOOT/BOOTX64.EFI \
+  --efi-boot boot/limine/limine-uefi-cd.bin \
   -efi-boot-part --efi-boot-image --protective-msdos-label \
   -o "$ISO_OUTPUT" "$STAGING_DIR"
 


### PR DESCRIPTION
This pull request adds significant improvements to the kernel build system and expands the project documentation with in-depth notes on early OS bootstrapping, linker scripts, and the Limine bootloader protocol. The most important changes are grouped below by theme.

**Build System Enhancements:**

* Added new build steps in `build.zig` for building a bootable ISO (`iso`), running the kernel in QEMU (`run`), and running in QEMU with a GDB server for debugging (`debug`). These steps automate invoking the ISO build script and QEMU with appropriate options, and ensure correct build dependencies among kernel, ISO, and run/debug steps.

**Documentation Expansion and Clarification:**

* Thoroughly rewrote and expanded `docs/phase_01/NOTES.md` to provide detailed explanations of the x86 boot chain, the purpose and structure of linker scripts, and the Limine boot protocol. The notes now include conceptual overviews, technical gotchas, practical fixes, and step-by-step evidence for successful kernel booting.

  - **Boot Process and Limine Protocol:**
    * Clarified the multi-stage boot process (power-on to kernel entry) and the role of Limine as a unifying bootloader for BIOS/UEFI, including the request/response mechanism for passing boot information to the kernel.
    * Documented practical issues and solutions related to Limine requests in Zig, linker section placement, and ISO 9660 filename truncation, as well as correct Limine config syntax and file layout.

  - **Linker Script and Backend Issues:**
    * Explained the importance of higher-half kernel mapping, the use of `AT()` and `. = ALIGN(4K);` in linker scripts, and the need to disable PIE and use the LLVM backend in Zig to ensure correct ELF output. Included verification evidence and lessons learned from debugging backend/linker issues.

  - **Troubleshooting and Lessons Learned:**
    * Added a comprehensive section on common pitfalls and their resolutions when setting up Limine, struct exports in Zig, and ELF alignment requirements, along with open questions and suggestions for future